### PR TITLE
add autocomplete field

### DIFF
--- a/gold-email-input.html
+++ b/gold-email-input.html
@@ -68,7 +68,7 @@ style this element.
           aria-describedby$="[[_ariaDescribedBy]]"
           validator="email-validator"
           bind-value="{{value}}"
-          autocomplete$="[[autocomplete]]"
+          autocomplete="email"
           name$="[[name]]">
 
       <template is="dom-if" if="[[errorMessage]]">


### PR DESCRIPTION
Apparently the `autocomplete` field has meaning. See: https://developers.google.com/web/fundamentals/input/form/label-and-name-inputs?hl=en

It worked by magic in some of the elements because they had a heuristic-approved name in the demo, but now it works regardless of the name.

/cc @morethanreal @cdata 
