### PR TITLE
Fix regular expression for email validation

### DIFF
--- a/email-validator.html
+++ b/email-validator.html
@@ -22,7 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ],
 
     validate: function(value) {
-      var re = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/i;
+      var re = /^[^@]+@[^@]+\.[a-z]{2,}$/i;
       return re.test(value);
     }
 


### PR DESCRIPTION
Very naive regex replaced with something more suitable for actual validation. Emails can contain more or less *any* characters, and what actually is an email, is very vague. I have users with non-ascii characters in their emails which are perfectly valid. This email uses anchors which the old version did not (which allowed invalid emails, such as `this@@ probably @@ isnt acorrect@email.com @@ right?` but would still validate. My regex, much more simple, will give a general gist of a correct email much more accurately than the old one would. 

If it's *too* vague, I can look at the RFC spec a bit more and adjust it accordingly. However, I believe this is fine for what we want: something, then `@`, then something, then a TLD..