### PR TITLE
add proper validation tests

### DIFF
--- a/email-validator.html
+++ b/email-validator.html
@@ -22,7 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ],
 
     validate: function(value) {
-      var re = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/i;
+      var re = /^[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i;
       return re.test(value);
     }
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -39,7 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
 
     suite('basic', function() {
-      test('invalid input is not ok', function() {
+      test('invalid input shows error', function() {
         var input = fixture('basic');
         input.value='1234';
         forceXIfStamp(input);
@@ -47,9 +47,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = Polymer.dom(input.root).querySelector('paper-input-container');
         assert.ok(container, 'paper-input-container exists');
         assert.isTrue(container.invalid);
+
+        var error = Polymer.dom(input.root).querySelector('paper-input-error');
+        assert.ok(error, 'paper-input-error exists');
+        assert.notEqual(getComputedStyle(error).display, 'none', 'error is not display:none');
       });
 
-      test('valid input is ok', function() {
+      test('valid input does not show error', function() {
         var input = fixture('basic');
         input.value='batman@gotham.org';
         forceXIfStamp(input);
@@ -57,17 +61,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var container = Polymer.dom(input.root).querySelector('paper-input-container');
         assert.ok(container, 'paper-input-container exists');
         assert.isFalse(container.invalid);
-      });
 
-
-      test('weird tlds are ok', function() {
-        var input = fixture('basic');
-        input.value='testing+contact@subdomain.domain.pizza';
-        forceXIfStamp(input);
-
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        assert.ok(container, 'paper-input-container exists');
-        assert.isFalse(container.invalid);
+        var error = Polymer.dom(input.root).querySelector('paper-input-error');
+        assert.ok(error, 'paper-input-error exists');
+        assert.equal(getComputedStyle(error).display, 'none', 'error is display:none');
       });
 
       test('empty required input shows error', function() {
@@ -87,6 +84,128 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var input = fixture('basic');
         assert.isTrue(input.inputElement.hasAttribute('aria-labelledby'))
         assert.equal(input.inputElement.getAttribute('aria-labelledby'), Polymer.dom(input.root).querySelector('label').id, 'aria-labelledby points to the label');
+      });
+
+    });
+
+    function testEmail(address, valid) {
+      var input = fixture('basic');
+      forceXIfStamp(input);
+
+      var container = Polymer.dom(input.root).querySelector('paper-input-container');
+      assert.ok(container, 'paper-input-container exists');
+
+      input.value = address;
+      var errorString = address + ' should be ' + (valid ? 'valid' : 'invalid');
+      assert.equal(container.invalid, !valid, errorString);
+    }
+
+    suite('valid email address validation', function() {
+    
+      test('valid email', function() {
+        testEmail('email@domain.com', true);
+      });
+
+      test('email with a dot in the address field', function() {
+        testEmail('firstname.lastname@domain.com', true);
+      });
+
+      test('email with a subdomain', function() {
+        testEmail('email@subdomain.domain.com', true);
+      });
+
+      test('weird tlds', function() {
+        testEmail('testing+contact@subdomain.domain.pizza', true);
+      });
+
+      test('plus sign is ok', function() {
+        testEmail('firstname+lastname@domain.com', true);
+      });
+
+      test('domain is valid ip', function() {
+        testEmail('email@123.123.123.123', true);
+      });
+
+      test('digits in address', function() {
+        testEmail('1234567890@domain.com', true);
+      });
+
+      test('dash in domain name', function() {
+        testEmail('email@domain-one.com', true);
+      });
+
+      test('dash in address field', function() {
+        testEmail('firstname-lastname@domain.com', true);
+      });
+
+      test('underscore in address field', function() {
+        testEmail('_______@domain-one.com', true);
+      });
+
+      test('dot in tld', function() {
+        testEmail('email@domain.co.jp', true);
+      });
+    });
+
+    suite('invalid email address validation', function() {
+      test('missing @ and domain', function() {
+        testEmail('plainaddress', false);
+      });
+
+      test('missing @', function() {
+        testEmail('email.domain.com', false);
+      });
+
+      test('garbage', function() {
+        testEmail('#@%^%#$@#$@#.com', false);
+      });
+
+      test('missing username', function() {
+        testEmail('@domain.com', false);
+      });
+
+      test('has spaces', function() {
+        testEmail('firstname lastname@domain.com', false);
+      });
+
+      test('encoded html', function() {
+        testEmail('Joe Smith <email@domain.com>', false);
+      });
+
+      test('two @ signs', function() {
+        testEmail('email@domain@domain.com', false);
+      });
+
+      test('leading . in address', function() {
+        testEmail('.email@domain.com', false);
+      });
+
+      test('trailing . in address', function() {
+        testEmail('email.@domain.com', false);
+      });
+
+      test('multiple . in address', function() {
+        testEmail('email..email@domain.com', false);
+      });
+
+      test('unicode in address', function() {
+        testEmail('あいうえお@domain.com', false);
+      });
+
+      test('text after address', function() {
+        testEmail('email@domain.com (Joe Smith)', false);
+      });
+
+      test('missing tld', function() {
+        testEmail('email@domain', false);
+      });
+
+      test('leading dash in front of tld', function() {
+        testEmail('email@-domain', false);
+      });
+
+      test('multiple dots in domain', function() {
+        testEmail('email@domain..com', false);
       });
 
     });


### PR DESCRIPTION
I've added most of the test cases from [here](http://blogs.msdn.com/b/testing123/archive/2009/02/05/email-address-test-cases.aspx). I've ignored:
- the ones that check for an invalid ip, since that's not a regex' job
- the ones that allow "" around the address and [ ] around the IP, since RFC 5322 has given up on those as well.

Initially some tests failed, so I've added the ^ and the $ to specify the start/end of input. Now the all pass. :tada: 

/cc @cdata @morethanreal @azakus 