### PR TITLE
Set the type of the input element to "email"

### DIFF
--- a/gold-email-input.html
+++ b/gold-email-input.html
@@ -75,7 +75,8 @@ style this element.
           inputmode$="[[inputmode]]"
           placeholder$="[[placeholder]]"
           readonly$="[[readonly]]"
-          size$="[[size]]">
+          size$="[[size]]"
+          type="email">
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error id="error">[[errorMessage]]</paper-input-error>


### PR DESCRIPTION
Focusing a `<gold-email-input>` element currently opens the generic iOS keyboard instead of the email keyboard.
This can be resolved by setting the type on the `<input>` element to `email`.