### PR TITLE
Adding type="email" to input for email keyboards on mobile

### DIFF
--- a/gold-email-input.html
+++ b/gold-email-input.html
@@ -69,6 +69,7 @@ style this element.
           validator="email-validator"
           bind-value="{{value}}"
           autocomplete="email"
+          type="email"
           name$="[[name]]"
           invalid="{{invalid}}"
           autofocus$="[[autofocus]]"


### PR DESCRIPTION
The email type prompts both the iOS and Android browsers to display slightly customized keyboards for email entry.