### PR TITLE
Fixes issues in #32

### DIFF
--- a/gold-email-input.html
+++ b/gold-email-input.html
@@ -149,21 +149,22 @@ style this element.
      * @return {boolean} Whether the input is currently valid or not.
      */
     validate: function() {
-      // Empty, non-required input is valid. A blank regex means everything is valid.
-      if ((!this.required && this.value == '') || this.regex == '') {
-        return true;
+      // Empty, non-required input is valid. A blank regex means everything is valid. Else, check value against regex.
+      var valid = ((!this.required && this.value == '') || this.regex == '') ? true : new RegExp(this.regex, "i").test(this.value);
+
+      // Check if validity has changed
+      if (valid == this.invalid) {
+
+        // Update `this.invalid` since it's data-bound to container
+        this.invalid = !valid;
+
+        // Update container's addons (i.e. the custom error-message).
+        this.$.container.updateAddons({
+          inputElement: this.$.input,
+          value: this.value,
+          invalid: !valid
+        });
       }
-
-      // A blank regex mean everything is allowed.
-      var valid = new RegExp(this.regex, "i").test(this.value);
-
-      // Update the container and its addons (i.e. the custom error-message).
-      this.$.container.invalid = !valid;
-      this.$.container.updateAddons({
-        inputElement: this.$.input,
-        value: this.value,
-        invalid: !valid
-      });
 
       return valid;
     },


### PR DESCRIPTION
@notwaldorf - referencing #32, the expected `auto-validate` behaviours are:

Case 1: When auto-validate=true and required=true, an empty input should be **invalid**.
Case 2: When auto-validate=true and required=false, an empty input should be **valid**.

Currently, that's not the case - repro: http://jsbin.com/hodeyakuzu/edit?html,output

Notes:

1. I moved `value` observer from the `properties` object to the `observers` array because it is probably cleaner (I want to avoid any unexpected behaviour when Polymer mixes duplicate properties).
2. Removed the `_handleAutoValidate()` call from `ready()` callback since a) we always want to validate even if value is empty; and b) `_onValueChanged()` will definitely trigger once on first load.
3. Check if `paper-input-container` actually needs updating before updating.