### PR TITLE
Email specific keyboard on mobile devices

### DIFF
--- a/gold-email-input.html
+++ b/gold-email-input.html
@@ -62,21 +62,22 @@ style this element.
       <label hidden$="[[!label]]">[[label]]</label>
 
       <input is="iron-input" id="input"
-          required$="[[required]]"
-          disabled$="[[disabled]]"
-          aria-labelledby$="[[_ariaLabelledBy]]"
-          aria-describedby$="[[_ariaDescribedBy]]"
-          validator="email-validator"
-          bind-value="{{value}}"
-          autocomplete="email"
-          autocapitalize="none"
-          name$="[[name]]"
-          invalid="{{invalid}}"
-          autofocus$="[[autofocus]]"
-          inputmode$="[[inputmode]]"
-          placeholder$="[[placeholder]]"
-          readonly$="[[readonly]]"
-          size$="[[size]]">
+        type="[[type]]"
+        required$="[[required]]"
+        disabled$="[[disabled]]"
+        aria-labelledby$="[[_ariaLabelledBy]]"
+        aria-describedby$="[[_ariaDescribedBy]]"
+        validator="email-validator"
+        bind-value="{{value}}"
+        autocomplete="email"
+        autocapitalize="none"
+        name$="[[name]]"
+        invalid="{{invalid}}"
+        autofocus$="[[autofocus]]"
+        inputmode$="[[inputmode]]"
+        placeholder$="[[placeholder]]"
+        readonly$="[[readonly]]"
+        size$="[[size]]">
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error id="error">[[errorMessage]]</paper-input-error>
@@ -126,7 +127,16 @@ style this element.
       '_onFocusedChanged(focused)'
     ],
 
-    ready: function() {
+    attached: function () {
+
+      var form = this._getForm();
+      if (form != null
+            && form.hasAttribute('novalidate')) {
+        this.type = 'email';
+      }
+    },
+
+    ready: function () {
       // If there's an initial input, validate it.
       if (this.value)
         this._handleAutoValidate();
@@ -176,6 +186,18 @@ style this element.
     _onFocusedChanged: function(focused) {
       if (!focused) {
         this._handleAutoValidate();
+      }
+    },
+
+    /**
+     * Finds the form associated with the input element up the tree
+     **/
+    _getForm: function () {
+
+      if (this.form) return this.form;
+      var parent = this;
+      while (parent = parent.parentElement) {
+        if (parent.tagName.toUpperCase() === 'FORM') return parent;
       }
     }
   })

--- a/test/basic.html
+++ b/test/basic.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <!--
 @license
 Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
@@ -34,6 +34,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <test-fixture id="basic">
     <template>
       <gold-email-input auto-validate required error-message="error"></gold-email-input>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="input-type-no-form">
+    <template>
+      <gold-email-input></gold-email-input>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="input-type-with-form-novalidate-not-set">
+    <template>
+      <form>
+        <gold-email-input></gold-email-input>
+      </form>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="input-type-with-form-novalidate-set">
+    <template>
+      <form novalidate>
+        <gold-email-input></gold-email-input>
+      </form>
     </template>
   </test-fixture>
 
@@ -200,6 +222,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     });
 
+    suite('input-type', function () {
+
+      test('when has no form, type set to null', function (done) {
+
+        var element = fixture('input-type-no-form');
+        forceXIfStamp(element);
+
+        var input = Polymer.dom(element.root).querySelector('input');
+        assert.equal(null, input.getAttribute('type'));
+
+        done();
+      });
+
+      test('when has form, but novalidate is not set, type set to null', function (done) {
+
+        var element = fixture('input-type-with-form-novalidate-not-set');
+        forceXIfStamp(element);
+
+        var input = element.querySelector('input');
+        assert.equal(null, input.getAttribute('type'));
+
+        done();
+      });
+
+      test('when has form, novalidate is set, type set to "email"', function (done) {
+
+        var element = fixture('input-type-with-form-novalidate-set');
+        forceXIfStamp(element);
+
+        var input = element.querySelector('input');
+        assert.equal('email', input.getAttribute('type'));
+
+        done();
+      });
+
+    });
   </script>
 
 </body>


### PR DESCRIPTION
Checks for parent form element having a novalidate attribute, if one is
found then set the type on the input element to "email" - which shows
the right keyboard

This is needed because setting email when novalidate is not set causes
the browser native validation (grr) to kick in

