### PR TITLE
add type=input and fix validation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -36,6 +36,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div class="vertical-section">
       <gold-email-input auto-validate value="batman@gotham.org"></gold-email-input>
       <gold-email-input auto-validate value="not-a-thing.email"></gold-email-input>
+      <gold-email-input auto-validate label="custom regex, needs to ends in .cat"
+          regex='^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+.cat$'
+          value="felix@meow.car"></gold-email-input>
     </div>
 
     <h4>Custom error message, auto-validates on blur</h4>

--- a/gold-email-input.html
+++ b/gold-email-input.html
@@ -62,6 +62,7 @@ style this element.
       <label hidden$="[[!label]]">[[label]]</label>
 
       <input is="iron-input" id="input"
+          type="email"
           required$="[[required]]"
           disabled$="[[disabled]]"
           aria-labelledby$="[[_ariaLabelledBy]]"
@@ -108,13 +109,15 @@ style this element.
       },
 
       /**
-       * The regular expression used to validate the email. Defaults to the
-       * regular expression defined in the spec: http://www.w3.org/TR/html-markup/input.email.html#input.email.attrs.value.single.
-       * If left blank, then no validation will be applied.
+       * The regular expression used to validate the email. By default, the
+       * input is of type=email and uses the native input regex, as defined in
+       * the spec: http://www.w3.org/TR/html-markup/input.email.html#input.email.attrs.value.single.
+       * You can override this if you want your email to be validated against
+       * a custom regex. If the empty string, then no validation will be applied.
        */
       regex: {
         type: String,
-        value: '^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$'
+        value: null
       },
 
       value: {
@@ -150,12 +153,22 @@ style this element.
      * @return {boolean} Whether the input is currently valid or not.
      */
     validate: function() {
-      // Empty, non-required input is valid. A blank regex means everything is valid. Else, check value against regex.
-      var valid = ((!this.required && this.value == '') || this.regex == '') ? true : new RegExp(this.regex, "i").test(this.value);
+
+      var valid;
+
+      // Empty, non-required input is valid.
+      if (!this.required && this.value == '') {
+        valid = true;
+      } else if (this.regex === null) {
+        // If the regex isn't set, then use the native validator.
+        valid = this.$.input.validate();
+      } else {
+        // A blank regex means everything is valid. Else, check value against regex.
+        valid = new RegExp(this.regex, "i").test(this.value);
+      }
 
       // Check if validity has changed
       if (valid == this.invalid) {
-
         // Update `this.invalid` since it's data-bound to container
         this.invalid = !valid;
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -37,6 +37,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="custom-regex">
+    <template>
+      <gold-email-input auto-validate required regex='.*cat' error-message="error"></gold-email-input>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="no-regex">
+    <template>
+      <gold-email-input auto-validate required regex='' error-message="error"></gold-email-input>
+    </template>
+  </test-fixture>
+
   <script>
 
     suite('basic', function() {
@@ -98,8 +110,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     });
 
-    function testEmail(address, valid) {
-      var input = fixture('basic');
+    function testEmail(fixtureName, address, valid) {
+      var input = fixture(fixtureName);
       forceXIfStamp(input);
 
       var container = Polymer.dom(input.root).querySelector('paper-input-container');
@@ -113,89 +125,115 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     suite('valid email address validation', function() {
 
       test('valid email', function() {
-        testEmail('email@domain.com', true);
+        testEmail('basic', 'email@domain.com', true);
       });
 
       test('email with a dot in the address field', function() {
-        testEmail('firstname.lastname@domain.com', true);
+        testEmail('basic', 'firstname.lastname@domain.com', true);
       });
 
       test('email with a subdomain', function() {
-        testEmail('email@subdomain.domain.com', true);
+        testEmail('basic', 'email@subdomain.domain.com', true);
       });
 
       test('weird tlds', function() {
-        testEmail('testing+contact@subdomain.domain.pizza', true);
+        testEmail('basic', 'testing+contact@subdomain.domain.pizza', true);
       });
 
       test('plus sign is ok', function() {
-        testEmail('firstname+lastname@domain.com', true);
+        testEmail('basic', 'firstname+lastname@domain.com', true);
       });
 
       test('domain is valid ip', function() {
-        testEmail('email@123.123.123.123', true);
+        testEmail('basic', 'email@123.123.123.123', true);
       });
 
       test('digits in address', function() {
-        testEmail('1234567890@domain.com', true);
+        testEmail('basic', '1234567890@domain.com', true);
       });
 
       test('dash in domain name', function() {
-        testEmail('email@domain-one.com', true);
+        testEmail('basic', 'email@domain-one.com', true);
       });
 
       test('dash in address field', function() {
-        testEmail('firstname-lastname@domain.com', true);
+        testEmail('basic', 'firstname-lastname@domain.com', true);
       });
 
       test('underscore in address field', function() {
-        testEmail('_______@domain-one.com', true);
+        testEmail('basic', '_______@domain-one.com', true);
       });
 
       test('dot in tld', function() {
-        testEmail('email@domain.co.jp', true);
+        testEmail('basic', 'email@domain.co.jp', true);
       });
     });
 
     suite('invalid email address validation', function() {
       test('missing @ and domain', function() {
-        testEmail('plainaddress', false);
+        testEmail('basic', 'plainaddress', false);
       });
 
       test('missing @', function() {
-        testEmail('email.domain.com', false);
+        testEmail('basic', 'email.domain.com', false);
       });
 
       test('garbage', function() {
-        testEmail('#@%^%#$@#$@#.com', false);
+        testEmail('basic', '#@%^%#$@#$@#.com', false);
       });
 
       test('missing username', function() {
-        testEmail('@domain.com', false);
+        testEmail('basic', '@domain.com', false);
       });
 
       test('has spaces', function() {
-        testEmail('firstname lastname@domain.com', false);
+        testEmail('basic', 'firstname lastname@domain.com', false);
       });
 
       test('encoded html', function() {
-        testEmail('Joe Smith <email@domain.com>', false);
+        testEmail('basic', 'Joe Smith <email@domain.com>', false);
       });
 
       test('two @ signs', function() {
-        testEmail('email@domain@domain.com', false);
+        testEmail('basic', 'email@domain@domain.com', false);
       });
 
       test('unicode in address', function() {
-        testEmail('あいうえお@domain.com', false);
+        testEmail('basic', 'あいうえお@domain.com', false);
       });
 
       test('text after address', function() {
-        testEmail('email@domain.com (Joe Smith)', false);
+        testEmail('basic', 'email@domain.com (Joe Smith)', false);
       });
 
       test('multiple dots in domain', function() {
-        testEmail('email@domain..com', false);
+        testEmail('basic', 'email@domain..com', false);
+      });
+
+    });
+
+    suite('custom email address validation', function() {
+      test('invalid email', function() {
+        testEmail('custom-regex', 'batman', false);
+      });
+
+      test('valid email', function() {
+        testEmail('custom-regex', 'cat', true);
+      });
+
+      test('valid complex email', function() {
+        testEmail('custom-regex', 'supercat', true);
+      });
+
+    });
+
+    suite('empty regex means no validation', function() {
+      test('empty string is valid', function() {
+        testEmail('no-regex', '', true);
+      });
+
+      test('random string is valid', function() {
+        testEmail('no-regex', 'batman', true);
       });
 
     });


### PR DESCRIPTION
Add `type=email` to the input to get the automagic mobile keyboard on safari, and get rid of the default regex (since `input type=email` does its own validation)