### PR TITLE
New: Allow override of autocomplete

### DIFF
--- a/gold-email-input.html
+++ b/gold-email-input.html
@@ -75,7 +75,7 @@ style this element.
           aria-describedby$="[[_ariaDescribedBy]]"
           validator="email-validator"
           bind-value="{{value}}"
-          autocomplete="email"
+          autocomplete$="[[autocomplete]]"
           autocapitalize="none"
           minlength$="[[minlength]]"
           maxlength$="[[maxlength]]"
@@ -129,7 +129,12 @@ style this element.
         value: {
           type: String,
           observer: '_onValueChanged'
-        }
+        },
+          
+        autocomplete: {
+          type: String,
+          value: 'email'
+        },
       },
 
       observers: [


### PR DESCRIPTION
Per the HTML Standard, you should be able to specify optional tokens before email.

I'm leaving this more free form but if you want to lock it down more we could make it a prefix to enforce that this is email autocomplete. 

https://html.spec.whatwg.org/multipage/forms.html#autofilling-form-controls:-the-autocomplete-attribute